### PR TITLE
Added reclaim-log.txt to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 composer.lock
 composer.phar
+reclaim-log.txt


### PR DESCRIPTION
Avoids reclaim-log.txt showing up as untracked. Because it's not tracked intentionally.
