### PR TITLE
Default should be not settings a max_import_loop.

### DIFF
--- a/mods/twitter.class.php
+++ b/mods/twitter.class.php
@@ -132,7 +132,10 @@ class twitter_reclaim_module extends reclaim_module {
                     $data = self::map_data(json_decode($tmhOAuth->response['response'], true), $type);
                     parent::insert_posts($data);
 
-                    $reqOk = count($data) > 0 && $data[count($data)-1]["ext_guid"] != $lastid && $i < self::$max_import_loops;
+                    $reqOk = count($data) > 0 && $data[count($data)-1]["ext_guid"] != $lastid;
+                    if ( self::$max_import_loops > 0 && $i >= self::$max_import_loops )
+                        $reqOk = false;
+
                     if (!isset($lastid) && $reqOk) {
                         // store the last-seen-id, which is the first message of the first request
                         $lastseenid = $data[0]["ext_guid"];


### PR DESCRIPTION
Partly due to the cron job we have now, partly because it's less surprising as a user (why did it not import my full timeline).

The real (actual) problem here is not having a status indicator when force syncing from the admin interface. We can solve that properly though :-)
